### PR TITLE
Made new tiles that are to be used in Pario Marty

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/controller/PlayersController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/controller/PlayersController.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idi.idatt.boardgame.controller;
 
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.ArrayList;
@@ -8,7 +9,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A class representing the controller for the players in the game.
@@ -114,7 +114,8 @@ public class PlayersController {
       throw new IllegalArgumentException("Duplicate player name: " + name);
     }
 
-    players.add(new Player(name, piece));
+    // TODO: check if the player is a LadderGamePlayer or a ParioMartyPlayer
+    players.add(new LadderGamePlayer(name, piece));
   }
 
   /**

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/Board.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/Board.java
@@ -47,7 +47,7 @@ public record Board(Map<Integer, Tile> tiles) {
    * @return A {@link Map} containing all the tile types on the board.
    */
   public Map<Integer, String> getTileTypes() {
-    HashMap<Integer, String> tileTypes = new HashMap<>();
+    Map<Integer, String> tileTypes = new HashMap<>();
     tiles.keySet().forEach(tile -> {
       tileTypes.put(tile, tiles.get(tile).getTileType());
     });

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/BoardFactory.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/BoardFactory.java
@@ -8,7 +8,7 @@ import edu.ntnu.idi.idatt.boardgame.model.board.tile.RollAgainTile;
 import edu.ntnu.idi.idatt.boardgame.model.board.tile.Tile;
 import edu.ntnu.idi.idatt.boardgame.model.board.tile.TileType;
 import edu.ntnu.idi.idatt.boardgame.model.board.tile.WinnerTile;
-import edu.ntnu.idi.idatt.boardgame.model.io.board.BoardReaderGson;
+import edu.ntnu.idi.idatt.boardgame.model.io.board.LadderBoardReaderGson;
 import java.util.HashMap;
 import java.util.stream.IntStream;
 
@@ -185,20 +185,20 @@ public class BoardFactory {
   }
 
   private static Board vanillaLadderGameBoardJson() {
-    BoardReaderGson boardFileReader = new BoardReaderGson();
+    LadderBoardReaderGson boardFileReader = new LadderBoardReaderGson();
 
     return boardFileReader.readBoardFile("/JSON/LadderGameRegular.json", false);
   }
 
   private static Board specialLadderGameBoardJson() {
-    BoardReaderGson boardFileReader = new BoardReaderGson();
+    LadderBoardReaderGson boardFileReader = new LadderBoardReaderGson();
 
     return boardFileReader.readBoardFile(
         "/JSON/LadderGameSpecial.json", false);
   }
 
   private static Board ladderGameCustomJsonBoard(String filePath) {
-    BoardReaderGson boardFileReader = new BoardReaderGson();
+    LadderBoardReaderGson boardFileReader = new LadderBoardReaderGson();
     Board board;
 
     try {

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCoinsTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCoinsTile.java
@@ -14,8 +14,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class AddCoinsTile extends SpecialTile {
 
-  private final TileType tileType = TileType.ADD_COINS;
-
   /**
    * Constructor for the AddCoinsTile class.
    *
@@ -30,11 +28,7 @@ public class AddCoinsTile extends SpecialTile {
 
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
-  }
-
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
+    this.tileType = TileType.ADD_COINS;
   }
 
   @Override

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCoinsTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCoinsTile.java
@@ -1,0 +1,51 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tile;
+
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.AddCoinsAction;
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.TileAction;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+/**
+ * A special tile that adds coins to the player when they land on it. This is a tile that only
+ * appears in the ParioMarty game. This class extends the {@link SpecialTile} class.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class AddCoinsTile extends SpecialTile {
+
+  private final TileType tileType = TileType.ADD_COINS;
+
+  /**
+   * Constructor for the AddCoinsTile class.
+   *
+   * @param coinsToAdd the amount of coins to add to the player when they land on this tile
+   */
+  public AddCoinsTile(int tileNumber, int[] onscreenPosition, int coinsToAdd) {
+    try {
+      this.tileAction = new AddCoinsAction(coinsToAdd);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+
+    this.tileNumber = tileNumber;
+    this.onscreenPosition = onscreenPosition;
+  }
+
+  @Override
+  public String getTileType() {
+    return tileType.getTileType();
+  }
+
+  @Override
+  public void performAction(Player player) {
+    try {
+      tileAction.performAction(player);
+    } catch (NullPointerException e) {
+      throw new NullPointerException(e.getMessage());
+    } catch (ClassCastException e) {
+      throw new ClassCastException(e.getMessage());
+    }
+  }
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCrownTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCrownTile.java
@@ -7,8 +7,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 
 public class AddCrownTile extends SpecialTile {
 
-  private final TileType tileType = TileType.ADD_CROWN;
-
   /**
    * Constructor for the AddCrownTile class.
    *
@@ -19,11 +17,8 @@ public class AddCrownTile extends SpecialTile {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
     this.tileAction = new AddCrownAction();
-  }
 
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
+    this.tileType = TileType.ADD_CROWN;
   }
 
   @Override

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCrownTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/AddCrownTile.java
@@ -1,0 +1,45 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tile;
+
+
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.AddCrownAction;
+import edu.ntnu.idi.idatt.boardgame.model.player.ParioMartyPlayer;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+public class AddCrownTile extends SpecialTile {
+
+  private final TileType tileType = TileType.ADD_CROWN;
+
+  /**
+   * Constructor for the AddCrownTile class.
+   *
+   * @param tileNumber       The number of the tile on the board.
+   * @param onscreenPosition The position of the tile on the screen.
+   */
+  public AddCrownTile(int tileNumber, int[] onscreenPosition) {
+    this.tileNumber = tileNumber;
+    this.onscreenPosition = onscreenPosition;
+    this.tileAction = new AddCrownAction();
+  }
+
+  @Override
+  public String getTileType() {
+    return tileType.getTileType();
+  }
+
+  @Override
+  public void performAction(Player player) {
+    try {
+      if (((ParioMartyPlayer) player).getCoins() > 20) {
+        tileAction.performAction(player);
+        ((ParioMartyPlayer) player).removeCoins(20);
+
+      } else {
+        throw new IllegalArgumentException("Player does not have 20 or more coins.");
+      }
+
+    } catch (NullPointerException e) {
+      throw new NullPointerException(e.getMessage());
+    }
+  }
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTile.java
@@ -27,6 +27,9 @@ public class LadderTile extends SpecialTile {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
     this.destinationTileNumber = destinationTileNumber;
+
+    // initialize the tileAction with a LadderAction
+    this.tileAction = new LadderAction(destinationTileNumber);
   }
 
   /**
@@ -41,8 +44,6 @@ public class LadderTile extends SpecialTile {
   @Override
   public void performAction(Player player) {
     try {
-      // initialize the tileAction with a LadderAction
-      this.tileAction = new LadderAction(destinationTileNumber);
       tileAction.performAction(player);
     } catch (NullPointerException e) {
       throw new NullPointerException(e.getMessage());

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTile.java
@@ -13,7 +13,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class LadderTile extends SpecialTile {
 
-  private final TileType tileType = TileType.LADDER;
   private final int destinationTileNumber;
 
 
@@ -30,6 +29,7 @@ public class LadderTile extends SpecialTile {
 
     // initialize the tileAction with a LadderAction
     this.tileAction = new LadderAction(destinationTileNumber);
+    this.tileType = TileType.LADDER;
   }
 
   /**
@@ -48,11 +48,6 @@ public class LadderTile extends SpecialTile {
     } catch (NullPointerException e) {
       throw new NullPointerException(e.getMessage());
     }
-  }
-
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
   }
 
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/MowserTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/MowserTile.java
@@ -1,0 +1,71 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tile;
+
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.RemoveCoinsAction;
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.RemoveCrownAction;
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.ReturnToStartAction;
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.TileAction;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+public class MowserTile extends SpecialTile {
+
+  private final TileAction[] tileActions = new TileAction[4];
+
+
+  /**
+   * Constructor for the MowserTile class.
+   *
+   * @param tileNumber       The number of the tile on the board.
+   * @param onscreenPosition The position of the tile on the screen.
+   */
+  public MowserTile(int tileNumber, int[] onscreenPosition) {
+    this.tileNumber = tileNumber;
+    this.onscreenPosition = onscreenPosition;
+    this.tileType = TileType.MOWSER;
+
+    initializeTileActions();
+  }
+
+  /**
+   * Accesses the last {@link TileAction} that was performed on the tile.
+   *
+   * @return the last {@link TileAction} (represented as a String) that was performed on the tile.
+   */
+  public String getTileAction() {
+    if (tileAction == null) {
+      throw new NullPointerException("Tile action is null.");
+    }
+
+    return tileAction.getClass().getSimpleName();
+  }
+
+  @Override
+  public void performAction(Player player) {
+    try {
+      // initialize the tileAction with a random TileAction
+      int randomIndex = (int) (Math.random() * tileActions.length);
+      tileAction = tileActions[randomIndex];
+      try {
+        tileAction.performAction(player);
+      } catch (ClassCastException e) {
+        throw new ClassCastException(e.getMessage());
+      }
+
+    } catch (NullPointerException e) {
+      throw new NullPointerException(e.getMessage());
+    }
+  }
+
+
+  private void initializeTileActions() {
+    // remove 20 coins from the player
+    tileActions[0] = new RemoveCoinsAction(20);
+    // remove all coins from the player (very nice)
+    tileActions[1] = new RemoveCoinsAction(0);
+    // remove 1 crown from the player (again, very nice)
+    tileActions[2] = new RemoveCrownAction();
+    // move back to start
+    tileActions[3] = new ReturnToStartAction();
+  }
+
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTile.java
@@ -7,7 +7,6 @@ import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.RollAgainAction;
 import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.SwapPlayersAction;
 import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.TileAction;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
-import java.util.ArrayList;
 import java.util.List;
 
 /**

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTile.java
@@ -20,7 +20,6 @@ public class RandomActionTile extends SpecialTile {
 
   private final transient TileAction[] tileActions = new TileAction[4];
   private final transient Board board;
-  private final TileType tileType = TileType.RANDOM_ACTION;
 
   /**
    * Constructor for the RandomActionTile class.
@@ -36,6 +35,7 @@ public class RandomActionTile extends SpecialTile {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
     this.board = board;
+    this.tileType = TileType.RANDOM_ACTION;
 
     initializeTileActions();
   }
@@ -70,12 +70,6 @@ public class RandomActionTile extends SpecialTile {
       throw new NullPointerException(e.getMessage());
     }
   }
-
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
-  }
-
 
   private void initializeTileActions() {
     tileActions[0] = new ReturnToStartAction();

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RemoveCoinsTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RemoveCoinsTile.java
@@ -1,0 +1,48 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tile;
+
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.RemoveCoinsAction;
+import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.TileAction;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+/**
+ * A special tile that adds coins to the player when they land on it. This tile is used in the Pario
+ * Marty game.
+ */
+public class RemoveCoinsTile extends SpecialTile {
+
+  private final TileType tileType = TileType.REMOVE_COINS;
+
+  /**
+   * Constructor for the RemoveCoinsTile class.
+   *
+   * @param coinsToRemove the amount of coins to remove from the player when they land on this tile
+   */
+  public RemoveCoinsTile(int tileNumber, int[] onscreenPosition, int coinsToRemove) {
+    try {
+      TileAction tileAction = new RemoveCoinsAction(coinsToRemove);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+
+    this.tileNumber = coinsToRemove;
+    this.onscreenPosition = onscreenPosition;
+  }
+
+  @Override
+  public String getTileType() {
+    return tileType.getTileType();
+  }
+
+  @Override
+  public void performAction(Player player) {
+    try {
+      tileAction.performAction(player);
+    } catch (NullPointerException e) {
+      throw new NullPointerException(e.getMessage());
+    } catch (ClassCastException e) {
+      throw new ClassCastException(e.getMessage());
+    }
+  }
+
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RemoveCoinsTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RemoveCoinsTile.java
@@ -10,8 +10,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class RemoveCoinsTile extends SpecialTile {
 
-  private final TileType tileType = TileType.REMOVE_COINS;
-
   /**
    * Constructor for the RemoveCoinsTile class.
    *
@@ -26,11 +24,7 @@ public class RemoveCoinsTile extends SpecialTile {
 
     this.tileNumber = coinsToRemove;
     this.onscreenPosition = onscreenPosition;
-  }
-
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
+    this.tileType = TileType.REMOVE_COINS;
   }
 
   @Override

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
@@ -23,13 +23,13 @@ public class ReturnToStartTile extends SpecialTile {
   public ReturnToStartTile(int tileNumber, int[] onscreenPosition) {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
+
+    this.tileAction = new ReturnToStartAction();
   }
 
   @Override
   public void performAction(Player player) {
     try {
-      // initialize the tileAction with a ReturnToStartAction
-      this.tileAction = new ReturnToStartAction();
 
       tileAction.performAction(player);
     } catch (NullPointerException e) {

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
@@ -12,8 +12,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class ReturnToStartTile extends SpecialTile {
 
-  private final TileType tileType = TileType.RETURN_TO_START;
-
   /**
    * Constructor for the ReturnToStartTile class.
    *
@@ -25,6 +23,7 @@ public class ReturnToStartTile extends SpecialTile {
     this.onscreenPosition = onscreenPosition;
 
     this.tileAction = new ReturnToStartAction();
+    this.tileType = TileType.RETURN_TO_START;
   }
 
   @Override
@@ -35,11 +34,6 @@ public class ReturnToStartTile extends SpecialTile {
     } catch (NullPointerException e) {
       throw new NullPointerException(e.getMessage());
     }
-  }
-
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
   }
 
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTile.java
@@ -1,6 +1,5 @@
 package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
-import edu.ntnu.idi.idatt.boardgame.model.board.Board;
 import edu.ntnu.idi.idatt.boardgame.model.board.tileaction.ReturnToStartAction;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTile.java
@@ -23,6 +23,7 @@ public class RollAgainTile extends SpecialTile {
   public RollAgainTile(int tileNumber, int[] onscreenPosition) {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
+    this.tileAction = new RollAgainAction();
   }
 
   @Override
@@ -33,8 +34,7 @@ public class RollAgainTile extends SpecialTile {
   @Override
   public void performAction(Player player) {
     try {
-      RollAgainAction rollAgainAction = new RollAgainAction();
-      rollAgainAction.performAction(player);
+      tileAction.performAction(player);
     } catch (NullPointerException e) {
       throw new NullPointerException(e.getMessage());
     }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTile.java
@@ -12,8 +12,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class RollAgainTile extends SpecialTile {
 
-  private final TileType tileType = TileType.ROLL_AGAIN;
-
   /**
    * Constructor for a RollAgainTile.
    *
@@ -24,11 +22,8 @@ public class RollAgainTile extends SpecialTile {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
     this.tileAction = new RollAgainAction();
-  }
 
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
+    this.tileType = TileType.ROLL_AGAIN;
   }
 
   @Override

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/SpecialTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/SpecialTile.java
@@ -15,6 +15,7 @@ public abstract class SpecialTile implements Tile {
   protected int tileNumber;
   protected int[] onscreenPosition;
   protected TileAction tileAction;
+  protected TileType tileType;
 
   @Override
   public int getTileNumber() {
@@ -34,6 +35,8 @@ public abstract class SpecialTile implements Tile {
   public abstract void performAction(Player player);
 
   @Override
-  public abstract String getTileType();
+  public String getTileType() {
+    return tileType.getTileType();
+  }
 
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/TileType.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/TileType.java
@@ -62,6 +62,12 @@ public enum TileType {
     public String getTileType() {
       return "AddCrownTile";
     }
+  },
+  MOWSER() {
+    @Override
+    public String getTileType() {
+      return "MowserTile";
+    }
   };
 
   /**

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/TileType.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/TileType.java
@@ -44,6 +44,24 @@ public enum TileType {
     public String getTileType() {
       return "WinnerTile";
     }
+  },
+  ADD_COINS() {
+    @Override
+    public String getTileType() {
+      return "AddCoinsTile";
+    }
+  },
+  REMOVE_COINS() {
+    @Override
+    public String getTileType() {
+      return "RemoveCoinsTile";
+    }
+  },
+  ADD_CROWN() {
+    @Override
+    public String getTileType() {
+      return "AddCrownTile";
+    }
   };
 
   /**

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTile.java
@@ -24,14 +24,12 @@ public class WinnerTile extends SpecialTile {
   public WinnerTile(int tileNumber, int[] onscreenPosition) {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
+    this.tileAction = new WinnerAction();
   }
 
   @Override
   public void performAction(Player player) {
     try {
-      // initialize the tileAction with a WinnerAction
-      this.tileAction = new WinnerAction();
-
       tileAction.performAction(player);
     } catch (NullPointerException e) {
       throw new NullPointerException(e.getMessage());

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTile.java
@@ -12,9 +12,6 @@ import edu.ntnu.idi.idatt.boardgame.model.player.Player;
  */
 public class WinnerTile extends SpecialTile {
 
-  //
-  private final TileType tileType = TileType.WINNER;
-
   /**
    * Constructor for the WinnerTile class.
    *
@@ -25,6 +22,7 @@ public class WinnerTile extends SpecialTile {
     this.tileNumber = tileNumber;
     this.onscreenPosition = onscreenPosition;
     this.tileAction = new WinnerAction();
+    this.tileType = TileType.WINNER;
   }
 
   @Override
@@ -36,9 +34,5 @@ public class WinnerTile extends SpecialTile {
     }
   }
 
-  @Override
-  public String getTileType() {
-    return tileType.getTileType();
-  }
 
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCoinsAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCoinsAction.java
@@ -1,4 +1,56 @@
 package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
-public class AddCoinsAction {
+import edu.ntnu.idi.idatt.boardgame.model.player.ParioMartyPlayer;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+/**
+ * A special tile action that adds coins to a player in the ParioMarty game. The performAction
+ * method adds 5 coins to the player's coin count, and can only be performed by a player of type
+ * {@link ParioMartyPlayer}.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class AddCoinsAction implements TileAction {
+
+  private int coinsToAdd;
+
+  /**
+   * Constructor for the AddCoinsAction class.
+   *
+   * @param coinsToAdd the amount of coins to add to the player when performing the action
+   */
+  public AddCoinsAction(int coinsToAdd) {
+    if (coinsToAdd < 0) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+
+    this.coinsToAdd = coinsToAdd;
+  }
+
+  @Override
+  public void performAction(Player player) {
+    if (player == null) {
+      throw new NullPointerException("Player cannot be null");
+    }
+    try {
+      ((ParioMartyPlayer) player).addCoins(5);
+    } catch (ClassCastException e) {
+      throw new ClassCastException("Player is not of type ParioMartyPlayer");
+    }
+  }
+
+  /**
+   * Mutator method for the coinsToAdd field. This method sets the amount of coins to add to the
+   * player when performing the action.
+   *
+   * @param coinsToAdd the amount of coins to add to the player when performing the action
+   */
+  public void setCoinsToAdd(int coinsToAdd) {
+    if (coinsToAdd < 0) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+    this.coinsToAdd = coinsToAdd;
+  }
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCoinsAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCoinsAction.java
@@ -1,0 +1,4 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
+
+public class AddCoinsAction {
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCrownAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/AddCrownAction.java
@@ -1,0 +1,35 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
+
+import edu.ntnu.idi.idatt.boardgame.model.player.ParioMartyPlayer;
+
+/**
+ * A special tile action that adds a crown to a player in the ParioMarty game. The performAction
+ * method adds a crown to the player's crown count, and can only be performed by a player of type
+ * {@link ParioMartyPlayer}.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class AddCrownAction implements TileAction {
+
+  /**
+   * Constructor for the AddCrownAction class.
+   */
+  public AddCrownAction() {
+  }
+
+
+  @Override
+  public void performAction(edu.ntnu.idi.idatt.boardgame.model.player.Player player) {
+    if (player == null) {
+      throw new NullPointerException("Player cannot be null");
+    }
+    try {
+      ((ParioMartyPlayer) player).addCrowns(1);
+    } catch (ClassCastException e) {
+      throw new ClassCastException("Player is not of type ParioMartyPlayer");
+    }
+  }
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RemoveCoinsAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RemoveCoinsAction.java
@@ -1,0 +1,59 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
+
+import edu.ntnu.idi.idatt.boardgame.model.player.ParioMartyPlayer;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+/**
+ * A special tile action that removes coins to a player in the ParioMarty game. The performAction
+ * method removes a specified amount of coins to the player's coin count, and can only be performed
+ * by a player of type {@link ParioMartyPlayer}.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class RemoveCoinsAction implements TileAction {
+
+  private int coinsToRemove;
+
+  /**
+   * Constructor for the RemoveCoinsAction class.
+   *
+   * @param coinsToRemove the amount of coins to remove from the player when performing the action
+   */
+  public RemoveCoinsAction(int coinsToRemove) {
+    if (coinsToRemove < 0) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+
+    this.coinsToRemove = coinsToRemove;
+  }
+
+  @Override
+  public void performAction(Player player) {
+    if (player == null) {
+      throw new NullPointerException("Player cannot be null");
+    }
+
+    try {
+      // Set to 0 if the player has less coins than the amount to remove
+      ((ParioMartyPlayer) player).removeCoins(
+          Math.min(((ParioMartyPlayer) player).getCoins(), coinsToRemove));
+    } catch (ClassCastException e) {
+      throw new ClassCastException("Player is not of type ParioMartyPlayer");
+    }
+  }
+
+  /**
+   * Mutator method for the coinsToRemove field. This method sets the amount of coins to remove from
+   * the player when performing the action.
+   *
+   * @param coinsToRemove the amount of coins to remove from the player when performing the action
+   */
+  public void setCoinsToRemove(int coinsToRemove) {
+    if (coinsToRemove < 0) {
+      throw new IllegalArgumentException("Coins cannot be negative");
+    }
+    this.coinsToRemove = coinsToRemove;
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RemoveCrownAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RemoveCrownAction.java
@@ -1,0 +1,37 @@
+package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
+
+import edu.ntnu.idi.idatt.boardgame.model.player.ParioMartyPlayer;
+import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+
+/**
+ * A special tile action that removes a crown to a player in the ParioMarty game. The performAction
+ * method removes a crown to the player's crown count, and can only be performed by a player of type
+ * {@link ParioMartyPlayer}.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class RemoveCrownAction implements TileAction {
+
+  /**
+   * Constructor for the RemoveCrownAction class.
+   */
+  public RemoveCrownAction() {
+  }
+
+  @Override
+  public void performAction(Player player) {
+    if (player == null) {
+      throw new NullPointerException("Player cannot be null");
+    } else if (((ParioMartyPlayer) player).getCrowns() == 0) {
+      throw new IllegalArgumentException("Cannot remove crown from player with 0 crowns");
+    }
+
+    try {
+      ((ParioMartyPlayer) player).removeCrowns(1);
+    } catch (ClassCastException e) {
+      throw new ClassCastException("Player is not of type ParioMartyPlayer");
+    }
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/ReturnToStartAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/ReturnToStartAction.java
@@ -1,6 +1,5 @@
 package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
-import edu.ntnu.idi.idatt.boardgame.model.board.Board;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 
 /**

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardReaderGson.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardReaderGson.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.HashMap;
-import java.util.Objects;
 
 /**
  * A class that reads a board from a file in JSON format using the Gson library.
@@ -33,17 +32,17 @@ import java.util.Objects;
  * @version 1.0
  * @since 1.0
  */
-public class BoardReaderGson implements BoardFileReader, JsonDeserializer<Tile> {
+public class LadderBoardReaderGson implements BoardFileReader, JsonDeserializer<Tile> {
 
   private final Gson gson;
   private Board board;
 
   /**
-   * Constructor for the BoardReaderGson class. Reads a board from a JSON file in the GSON format.
-   * The file contains a JSON array of tiles, where each tile is represented as a JSON object, which
-   * gets translated into a {@link Board} object.
+   * Constructor for the LadderBoardReaderGson class. Reads a board from a JSON file in the GSON
+   * format. The file contains a JSON array of tiles, where each tile is represented as a JSON
+   * object, which gets translated into a {@link Board} object.
    */
-  public BoardReaderGson() {
+  public LadderBoardReaderGson() {
     gson = new GsonBuilder()
         .setPrettyPrinting()
         .registerTypeAdapter(Tile.class, this)
@@ -126,6 +125,7 @@ public class BoardReaderGson implements BoardFileReader, JsonDeserializer<Tile> 
       case RANDOM_ACTION -> new RandomActionTile(tileNumber, onscreenPosition, board);
       case WINNER -> new WinnerTile(tileNumber, onscreenPosition);
       case ROLL_AGAIN -> new RollAgainTile(tileNumber, onscreenPosition);
+      default -> throw new JsonParseException("Cannot add Pario Marty tile to a ladder game board");
     };
   }
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardWriterGson.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardWriterGson.java
@@ -18,16 +18,16 @@ import java.util.Map;
  * @version 1.0
  * @since 1.0
  */
-public class BoardWriterGson implements BoardFileWriter {
+public class LadderBoardWriterGson implements BoardFileWriter {
 
   private final Gson gson;
 
   /**
-   * Constructor for the BoardWriterGson class. Writes a {@link Board} object to a JSON file in the
-   * GSON format. The file contains a JSON array of tiles, where each tile is represented as a JSON
-   * object.
+   * Constructor for the LadderBoardWriterGson class. Writes a {@link Board} object to a JSON file
+   * in the GSON format. The file contains a JSON array of tiles, where each tile is represented as
+   * a JSON object.
    */
-  public BoardWriterGson() {
+  public LadderBoardWriterGson() {
     // Instantiate a new Gson object with pretty printing
     this.gson = new GsonBuilder().setPrettyPrinting().create();
   }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersFileReader.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersFileReader.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idi.idatt.boardgame.model.io.player;
 
+
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import java.util.List;
 import java.util.HashMap;

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersFileWriter.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersFileWriter.java
@@ -16,7 +16,7 @@ public interface PlayersFileWriter {
    * Writes a player to a new file so that it can be loaded later on by the user.
    *
    * @param fileDirectory directory to save the file to.
-   * @param players       {@link java.util.HashMap} containing the players to write to the file.
+   * @param players       {@link List} containing the players to write to the file.
    * @param fileName      name of the file to write to.
    */
   void writePlayersFile(String fileDirectory, String fileName, List<Player> players);

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersReaderCsv.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersReaderCsv.java
@@ -1,12 +1,12 @@
 package edu.ntnu.idi.idatt.boardgame.model.io.player;
 
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -31,7 +31,7 @@ public class PlayersReaderCsv implements PlayersFileReader {
       while ((line = br.readLine()) != null) {
         String[] values = line.split(",");
 
-        Player player = new Player(values[0], PlayerPiece.valueOf(values[1]));
+        Player player = new LadderGamePlayer(values[0], PlayerPiece.valueOf(values[1]));
         players.add(player);
       }
       return players;

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersWriterCsv.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersWriterCsv.java
@@ -2,11 +2,8 @@ package edu.ntnu.idi.idatt.boardgame.model.io.player;
 
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -25,7 +22,8 @@ public class PlayersWriterCsv implements PlayersFileWriter {
   }
 
   @Override
-  public void writePlayersFile(String fileDirectory, String fileName, List<Player> players) {
+  public void writePlayersFile(String fileDirectory, String fileName,
+      List<Player> players) {
     try (FileWriter fileWriter = new FileWriter(fileDirectory);
         BufferedWriter bufferedWriter = new BufferedWriter(fileWriter)) {
 

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/LadderGamePlayer.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/LadderGamePlayer.java
@@ -1,0 +1,24 @@
+package edu.ntnu.idi.idatt.boardgame.model.player;
+
+
+/**
+ * A player in the Ladder Game. This class extends the {@link Player} class and represents a player
+ * in the Ladder Game.
+ *
+ * @author siguraso & MagnusNaessanGaarder
+ * @version 1.0
+ * @since 1.0
+ */
+public class LadderGamePlayer extends Player {
+
+  /**
+   * Constructor for the LadderGamePlayer class.
+   *
+   * @param name  The name of the player.
+   * @param piece The piece that the player uses on the board, as defined in the {@link PlayerPiece}
+   *              enum.
+   */
+  public LadderGamePlayer(String name, PlayerPiece piece) {
+    super(name, piece);
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/ParioMartyPlayer.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/ParioMartyPlayer.java
@@ -1,0 +1,82 @@
+package edu.ntnu.idi.idatt.boardgame.model.player;
+
+/**
+ * A player in the ParioMarty game. This class extends the {@link Player} class and represents a
+ * player in the ParioMarty game.
+ *
+ * @author siguraso
+ * @version 1.0
+ * @since 1.0
+ */
+public class ParioMartyPlayer extends Player {
+
+  int coins = 0;
+  int crowns = 0;
+
+  /**
+   * Constructor for the ParioMartyPlayer class.
+   *
+   * @param name  The name of the player.
+   * @param piece The piece that the player uses on the board, as defined in the {@link PlayerPiece}
+   *              enum.
+   */
+  public ParioMartyPlayer(String name, PlayerPiece piece) {
+    super(name, piece);
+  }
+
+
+  /**
+   * Retrieves the number of coins the player has.
+   *
+   * @return The number of coins the player has.
+   */
+  public int getCoins() {
+    return coins;
+  }
+
+  /**
+   * Sets the number of coins the player has.
+   *
+   * @param coins The number of coins to set for the player.
+   */
+  public void addCoins(int coins) {
+    this.coins += coins;
+  }
+
+  /**
+   * Removes a specified number of coins from the player.
+   *
+   * @param coins The number of coins to remove from the player.
+   */
+  public void removeCoins(int coins) {
+    this.coins -= coins;
+  }
+
+  /**
+   * Retrieves the number of crowns the player has.
+   *
+   * @return The number of crowns the player has.
+   */
+  public int getCrowns() {
+    return crowns;
+  }
+
+  /**
+   * Sets the number of crowns the player has.
+   *
+   * @param crowns The number of crowns to set for the player.
+   */
+  public void addCrowns(int crowns) {
+    this.crowns += crowns;
+  }
+
+  /**
+   * Removes a specified number of crowns from the player.
+   *
+   * @param crowns The number of crowns to remove from the player.
+   */
+  public void removeCrowns(int crowns) {
+    this.crowns -= crowns;
+  }
+
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/Player.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/model/player/Player.java
@@ -1,16 +1,10 @@
 package edu.ntnu.idi.idatt.boardgame.model.player;
 
 import edu.ntnu.idi.idatt.boardgame.model.observerPattern.BoardGameObserver;
+
 import java.util.Arrays;
 
-/**
- * A player in a board game.
- *
- * @author siguraso & MagnusNaessanGaarder
- * @version 1.0
- * @since 1.0
- */
-public class Player implements BoardGameObserver {
+public abstract class Player implements BoardGameObserver {
 
   private final String name;
   private int position;
@@ -159,4 +153,6 @@ public class Player implements BoardGameObserver {
       moveForward(steps);
     }
   }
+
+
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/view/window/MainWindow.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/view/window/MainWindow.java
@@ -213,7 +213,7 @@ public class MainWindow implements Window {
         // define the action for the start game button to fetch a json file
         startGameButton.setOnAction(onPress -> {
           try {
-            showFileChooserJson();
+            jsonFileChooserSequence();
           } catch (IllegalStateException e) {
             warningDialog.update(
                 "There is something wrong with the provided board file: \n" + e.getMessage(),
@@ -330,7 +330,7 @@ public class MainWindow implements Window {
     fileButtons.setAlignment(Pos.CENTER);
 
     readButton.setOnAction(onPressed ->
-        showFileChooserCsv()
+        csvFileChooserSequence()
     );
 
     writeButton.setOnAction(onPressed ->
@@ -502,7 +502,7 @@ public class MainWindow implements Window {
     return numberOfDiceComponent;
   }
 
-  private void showFileChooserJson() {
+  private void jsonFileChooserSequence() {
     if (arePlayersInvalid()) {
       playerSelectionView.getStyleClass().add("player-selection-view-error");
       errorLabel.setText("Please fill in all player fields!");
@@ -529,7 +529,7 @@ public class MainWindow implements Window {
     }
   }
 
-  private void showFileChooserCsv() {
+  private void csvFileChooserSequence() {
     FileChooser fileChooser = new FileChooser();
     fileChooser.setTitle("Open CSV File");
 

--- a/src/main/resources/JSON/RandomActionBoard.json
+++ b/src/main/resources/JSON/RandomActionBoard.json
@@ -9,7 +9,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "destinationTileNumber": 89,
       "tileNumber": 2,
       "onscreenPosition": [
@@ -18,7 +18,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 3,
       "onscreenPosition": [
         2,
@@ -26,7 +26,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 4,
       "onscreenPosition": [
         3,
@@ -34,7 +34,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 5,
       "onscreenPosition": [
         4,
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 6,
       "onscreenPosition": [
         5,
@@ -50,7 +50,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 7,
       "onscreenPosition": [
         6,
@@ -58,7 +58,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 8,
       "onscreenPosition": [
         7,
@@ -66,7 +66,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 9,
       "onscreenPosition": [
         8,
@@ -74,7 +74,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 10,
       "onscreenPosition": [
         8,
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 11,
       "onscreenPosition": [
         7,
@@ -90,7 +90,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 12,
       "onscreenPosition": [
         6,
@@ -98,7 +98,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 13,
       "onscreenPosition": [
         5,
@@ -106,7 +106,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 14,
       "onscreenPosition": [
         4,
@@ -114,7 +114,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 15,
       "onscreenPosition": [
         3,
@@ -122,7 +122,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 16,
       "onscreenPosition": [
         2,
@@ -130,7 +130,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 17,
       "onscreenPosition": [
         1,
@@ -138,7 +138,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 18,
       "onscreenPosition": [
         0,
@@ -146,7 +146,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 19,
       "onscreenPosition": [
         0,
@@ -154,7 +154,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 20,
       "onscreenPosition": [
         1,
@@ -162,7 +162,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 21,
       "onscreenPosition": [
         2,
@@ -170,7 +170,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 22,
       "onscreenPosition": [
         3,
@@ -178,7 +178,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 23,
       "onscreenPosition": [
         4,
@@ -186,7 +186,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 24,
       "onscreenPosition": [
         5,
@@ -194,7 +194,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 25,
       "onscreenPosition": [
         6,
@@ -202,7 +202,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 26,
       "onscreenPosition": [
         7,
@@ -210,7 +210,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 27,
       "onscreenPosition": [
         8,
@@ -218,7 +218,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 28,
       "onscreenPosition": [
         8,
@@ -226,7 +226,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 29,
       "onscreenPosition": [
         7,
@@ -234,7 +234,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 30,
       "onscreenPosition": [
         6,
@@ -242,7 +242,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 31,
       "onscreenPosition": [
         5,
@@ -250,7 +250,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 32,
       "onscreenPosition": [
         4,
@@ -258,7 +258,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 33,
       "onscreenPosition": [
         3,
@@ -266,7 +266,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 34,
       "onscreenPosition": [
         2,
@@ -274,7 +274,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 35,
       "onscreenPosition": [
         1,
@@ -282,7 +282,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 36,
       "onscreenPosition": [
         0,
@@ -290,7 +290,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 37,
       "onscreenPosition": [
         0,
@@ -298,7 +298,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 38,
       "onscreenPosition": [
         1,
@@ -306,7 +306,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 39,
       "onscreenPosition": [
         2,
@@ -314,7 +314,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 40,
       "onscreenPosition": [
         3,
@@ -322,7 +322,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 41,
       "onscreenPosition": [
         4,
@@ -330,7 +330,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 42,
       "onscreenPosition": [
         5,
@@ -338,7 +338,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 43,
       "onscreenPosition": [
         6,
@@ -346,7 +346,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 44,
       "onscreenPosition": [
         7,
@@ -354,7 +354,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 45,
       "onscreenPosition": [
         8,
@@ -362,7 +362,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 46,
       "onscreenPosition": [
         8,
@@ -370,7 +370,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 47,
       "onscreenPosition": [
         7,
@@ -378,7 +378,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 48,
       "onscreenPosition": [
         6,
@@ -386,7 +386,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 49,
       "onscreenPosition": [
         5,
@@ -394,7 +394,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 50,
       "onscreenPosition": [
         4,
@@ -402,7 +402,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 51,
       "onscreenPosition": [
         3,
@@ -410,7 +410,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 52,
       "onscreenPosition": [
         2,
@@ -418,7 +418,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 53,
       "onscreenPosition": [
         1,
@@ -426,7 +426,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 54,
       "onscreenPosition": [
         0,
@@ -434,7 +434,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 55,
       "onscreenPosition": [
         0,
@@ -442,7 +442,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 56,
       "onscreenPosition": [
         1,
@@ -450,7 +450,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 57,
       "onscreenPosition": [
         2,
@@ -458,7 +458,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 58,
       "onscreenPosition": [
         3,
@@ -466,7 +466,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 59,
       "onscreenPosition": [
         4,
@@ -474,7 +474,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 60,
       "onscreenPosition": [
         5,
@@ -482,7 +482,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 61,
       "onscreenPosition": [
         6,
@@ -490,7 +490,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 62,
       "onscreenPosition": [
         7,
@@ -498,7 +498,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 63,
       "onscreenPosition": [
         8,
@@ -506,7 +506,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 64,
       "onscreenPosition": [
         8,
@@ -514,7 +514,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 65,
       "onscreenPosition": [
         7,
@@ -522,7 +522,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 66,
       "onscreenPosition": [
         6,
@@ -530,7 +530,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 67,
       "onscreenPosition": [
         5,
@@ -538,7 +538,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 68,
       "onscreenPosition": [
         4,
@@ -546,7 +546,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 69,
       "onscreenPosition": [
         3,
@@ -554,7 +554,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 70,
       "onscreenPosition": [
         2,
@@ -562,7 +562,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 71,
       "onscreenPosition": [
         1,
@@ -570,7 +570,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 72,
       "onscreenPosition": [
         0,
@@ -578,7 +578,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 73,
       "onscreenPosition": [
         0,
@@ -586,7 +586,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 74,
       "onscreenPosition": [
         1,
@@ -594,7 +594,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 75,
       "onscreenPosition": [
         2,
@@ -602,7 +602,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 76,
       "onscreenPosition": [
         3,
@@ -610,7 +610,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 77,
       "onscreenPosition": [
         4,
@@ -618,7 +618,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 78,
       "onscreenPosition": [
         5,
@@ -626,7 +626,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 79,
       "onscreenPosition": [
         6,
@@ -634,7 +634,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 80,
       "onscreenPosition": [
         7,
@@ -642,7 +642,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 81,
       "onscreenPosition": [
         8,
@@ -650,7 +650,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 82,
       "onscreenPosition": [
         8,
@@ -658,7 +658,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 83,
       "onscreenPosition": [
         7,
@@ -666,7 +666,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 84,
       "onscreenPosition": [
         6,
@@ -674,7 +674,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 85,
       "onscreenPosition": [
         5,
@@ -682,7 +682,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 86,
       "onscreenPosition": [
         4,
@@ -690,7 +690,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 87,
       "onscreenPosition": [
         3,
@@ -698,7 +698,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 88,
       "onscreenPosition": [
         2,
@@ -706,7 +706,7 @@
       ]
     },
     {
-      "tileType": "WINNER",
+      "tileType": "RANDOM_ACTION",
       "tileNumber": 89,
       "onscreenPosition": [
         1,

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/LadderTileTest.java
@@ -2,21 +2,20 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class LadderTileTest {
 
   private LadderTile tile;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     tile = new LadderTile(1, new int[]{0, 0}, 2);
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/NormalTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/NormalTileTest.java
@@ -2,7 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 class NormalTileTest {
 
   private Tile tile;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     tile = new NormalTile(1, new int[]{0, 0});
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RandomActionTileTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import edu.ntnu.idi.idatt.boardgame.model.board.Board;
 import edu.ntnu.idi.idatt.boardgame.model.board.BoardFactory;
 import edu.ntnu.idi.idatt.boardgame.model.board.BoardType;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.ArrayList;
@@ -14,8 +15,8 @@ import org.junit.jupiter.api.Test;
 class RandomActionTileTest {
 
   private Tile tile;
-  private Player player;
-  private Player player1;
+  private LadderGamePlayer player;
+  private LadderGamePlayer player1;
   private ArrayList<Player> players;
 
   @BeforeEach
@@ -25,8 +26,8 @@ class RandomActionTileTest {
 
     tile = new RandomActionTile(1, new int[]{0, 0}, board);
 
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
-    player1 = new Player("TestPlayer1", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player1 = new LadderGamePlayer("TestPlayer1", PlayerPiece.EVIL_PAUL);
 
     player1.moveTo(2);
     player.moveTo(5);

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/ReturnToStartTileTest.java
@@ -2,7 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 class ReturnToStartTileTest {
 
   private Tile tile;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     tile = new ReturnToStartTile(1, new int[]{0, 0});
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/RollAgainTileTest.java
@@ -2,7 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 class RollAgainTileTest {
 
   private Tile tile;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     tile = new RollAgainTile(1, new int[]{0, 0});
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTileTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tile/WinnerTileTest.java
@@ -2,7 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 class WinnerTileTest {
 
   private Tile tile;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     tile = new WinnerTile(1, new int[]{0, 0});
-    player = new Player("TestPlayer", PlayerPiece.EVIL_PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.EVIL_PAUL);
   }
 
   @Test

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/LadderActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/LadderActionTest.java
@@ -2,17 +2,18 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.Test;
 
 class LadderActionTest {
+
   @Test
   void performAction() {
     // Arrange
     int destination = 5;
     LadderAction ladderAction = new LadderAction(destination);
-    Player player = new Player("TestPlayer", PlayerPiece.MARIOTINELLI);
+    LadderGamePlayer player = new LadderGamePlayer("TestPlayer", PlayerPiece.MARIOTINELLI);
 
     // Act
     ladderAction.performAction(player);
@@ -20,11 +21,12 @@ class LadderActionTest {
     // Assert
     assertEquals(destination, player.getPosition());
   }
+
   @Test
   void testNegativePerformAction() {
     // Arrange
     int destination = -5;
-    Player player = new Player("TestPlayer", PlayerPiece.MARIOTINELLI);
+    LadderGamePlayer player = new LadderGamePlayer("TestPlayer", PlayerPiece.MARIOTINELLI);
 
     // Act & Assert
     assertThrows(IllegalArgumentException.class, () -> new LadderAction(91));

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/MoveToRandomTileActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/MoveToRandomTileActionTest.java
@@ -6,7 +6,7 @@ import edu.ntnu.idi.idatt.boardgame.model.board.Board;
 import edu.ntnu.idi.idatt.boardgame.model.board.BoardFactory;
 import edu.ntnu.idi.idatt.boardgame.model.board.BoardType;
 import edu.ntnu.idi.idatt.boardgame.model.board.tile.Tile;
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
@@ -18,7 +18,7 @@ class MoveToRandomTileActionTest {
   private HashMap<Integer, Tile> tiles;
   private Board board;
   private MoveToRandomTileAction moveToRandomTileAction;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
@@ -27,7 +27,7 @@ class MoveToRandomTileActionTest {
         .createBoard(BoardType.LADDER_GAME_SPECIAL, false, null).tiles();
     board = new Board(tiles);
     moveToRandomTileAction = new MoveToRandomTileAction(board);
-    player = new Player("TestPlayer", PlayerPiece.MARIOTINELLI);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.MARIOTINELLI);
   }
 
   @AfterEach

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/ReturnToStartActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/ReturnToStartActionTest.java
@@ -2,20 +2,21 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ReturnToStartActionTest {
+
   private ReturnToStartAction returnToStartAction;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     returnToStartAction = new ReturnToStartAction();
-    player = new Player("TestPlayer", PlayerPiece.MARIOTINELLI);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.MARIOTINELLI);
   }
 
   @AfterEach

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RollAgainActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/RollAgainActionTest.java
@@ -2,21 +2,22 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class RollAgainActionTest {
+
   private RollAgainAction action;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     // Arrange
     action = new RollAgainAction();
-    player = new Player("TestPlayer", PlayerPiece.PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.PAUL);
   }
 
   @AfterEach

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/SwapPlayersActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/SwapPlayersActionTest.java
@@ -2,6 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.ArrayList;
@@ -10,14 +11,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SwapPlayersActionTest {
+
   private Player player1;
   private Player player2;
   private SwapPlayersAction swapPlayersAction;
 
   @BeforeEach
   void setUp() {
-    player1 = new Player("Player 1", PlayerPiece.MY_LOVE);
-    player2 = new Player("Player 2", PlayerPiece.KONKEY_DONG);
+    player1 = new LadderGamePlayer("LadderGamePlayer 1", PlayerPiece.MY_LOVE);
+    player2 = new LadderGamePlayer("LadderGamePlayer 2", PlayerPiece.KONKEY_DONG);
     swapPlayersAction = new SwapPlayersAction();
   }
 
@@ -73,8 +75,8 @@ class SwapPlayersActionTest {
     ArrayList<Player> players = new ArrayList<>();
     players.add(player1);
     players.add(player2);
-    players.add(new Player("Player 3", PlayerPiece.MY_LOVE_WITH_HAT));
-    players.add(new Player("Player 4", PlayerPiece.EVIL_PAUL));
+    players.add(new LadderGamePlayer("LadderGamePlayer 3", PlayerPiece.MY_LOVE_WITH_HAT));
+    players.add(new LadderGamePlayer("LadderGamePlayer 4", PlayerPiece.EVIL_PAUL));
     swapPlayersAction.setPlayers(players);
 
     // Act
@@ -126,8 +128,8 @@ class SwapPlayersActionTest {
     ArrayList<Player> players = new ArrayList<>();
     players.add(player1);
     players.add(player2);
-    players.add(new Player("Player 3", PlayerPiece.MY_LOVE_WITH_HAT));
-    players.add(new Player("Player 4", PlayerPiece.EVIL_PAUL));
+    players.add(new LadderGamePlayer("LadderGamePlayer 3", PlayerPiece.MY_LOVE_WITH_HAT));
+    players.add(new LadderGamePlayer("LadderGamePlayer 4", PlayerPiece.EVIL_PAUL));
 
     // Act
     swapPlayersAction.setPlayers(players);

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/WinnerActionTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/board/tileaction/WinnerActionTest.java
@@ -2,20 +2,21 @@ package edu.ntnu.idi.idatt.boardgame.model.board.tileaction;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class WinnerActionTest {
+
   private WinnerAction winnerAction;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     winnerAction = new WinnerAction();
-    player = new Player("Player 1", PlayerPiece.PAUL);
+    player = new LadderGamePlayer("Player 1", PlayerPiece.PAUL);
   }
 
   @AfterEach

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/dice/DiceTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/dice/DiceTest.java
@@ -2,7 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.dice;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,14 +11,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class DiceTest {
+
   private Dice dice;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     // Arrange
     dice = new Dice(2, 6);
-    player = new Player("TestPlayer", PlayerPiece.LOCKED_IN_SNOWMAN);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.LOCKED_IN_SNOWMAN);
     dice.addObserver(player);
   }
 
@@ -44,7 +45,8 @@ class DiceTest {
 
   @Test
   void testObserverPattern() {
-    Player newPlayer = new Player("testPlayer2", PlayerPiece.PROPELLER_ACCESSORIES);
+    LadderGamePlayer newPlayer = new LadderGamePlayer("testPlayer2",
+        PlayerPiece.PROPELLER_ACCESSORIES);
     // Test add
     assertDoesNotThrow(() -> dice.addObserver(newPlayer));
     assertTrue(dice.getObservers().contains(newPlayer));

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/dice/DieTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/dice/DieTest.java
@@ -2,10 +2,9 @@ package edu.ntnu.idi.idatt.boardgame.model.dice;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import edu.ntnu.idi.idatt.boardgame.model.player.Player;
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,13 +13,13 @@ import org.junit.jupiter.api.Test;
 class DieTest {
 
   private Die die;
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
     // Arrange
     die = new Die(6);
-    player = new Player("TestPlayer", PlayerPiece.LOCKED_IN_SNOWMAN);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.LOCKED_IN_SNOWMAN);
     die.addObserver(player);
   }
 
@@ -44,7 +43,8 @@ class DieTest {
 
   @Test
   void testObserverPattern() {
-    Player newPlayer = new Player("testPlayer2", PlayerPiece.PROPELLER_ACCESSORIES);
+    LadderGamePlayer newPlayer = new LadderGamePlayer("testPlayer2",
+        PlayerPiece.PROPELLER_ACCESSORIES);
     // Test add
     assertDoesNotThrow(() -> die.addObserver(newPlayer));
     assertTrue(die.getObservers().contains(newPlayer));
@@ -83,7 +83,7 @@ class DieTest {
 
     assertThrows(NullPointerException.class, () -> die.removeObserver(null));
     assertThrows(IllegalArgumentException.class, () ->
-        die.removeObserver(new Player("testPlayer2", PlayerPiece.PROPELLER_ACCESSORIES)));
+        die.removeObserver(new LadderGamePlayer("testPlayer2", PlayerPiece.PROPELLER_ACCESSORIES)));
 
     assertThrows(NullPointerException.class, () -> die.notifyObservers(null));
     assertThrows(IllegalArgumentException.class, () -> die.notifyObservers(new int[]{}));

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardReaderGsonTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardReaderGsonTest.java
@@ -10,13 +10,13 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class BoardReaderGsonTest {
+class LadderBoardReaderGsonTest {
 
-  private BoardReaderGson boardReaderGson;
+  private LadderBoardReaderGson ladderBoardReaderGson;
 
   @BeforeEach
   void setUp() {
-    boardReaderGson = new BoardReaderGson();
+    ladderBoardReaderGson = new LadderBoardReaderGson();
   }
 
 
@@ -29,7 +29,7 @@ class BoardReaderGsonTest {
     Board board = null;
 
     try {
-      board = boardReaderGson.readBoardFile(filePath, true);
+      board = ladderBoardReaderGson.readBoardFile(filePath, true);
     } catch (Exception e) {
       fail("Should not throw an exception");
     }
@@ -54,7 +54,7 @@ class BoardReaderGsonTest {
     Board board2 = null;
 
     try {
-      board2 = boardReaderGson.readBoardFile("/JSON/LadderGameSpecial.json",
+      board2 = ladderBoardReaderGson.readBoardFile("/JSON/LadderGameSpecial.json",
           false);
     } catch (Exception e) {
       fail("Should not throw an exception");
@@ -85,7 +85,7 @@ class BoardReaderGsonTest {
     // Negative tests
 
     try {
-      board = boardReaderGson.readBoardFile("src/test/resources/JSON/60DAYSSSS.json", true);
+      board = ladderBoardReaderGson.readBoardFile("src/test/resources/JSON/60DAYSSSS.json", true);
       fail("Should throw an exception");
     } catch (RuntimeException e) {
       if (!e.getMessage().contains("File not found") &&
@@ -98,7 +98,7 @@ class BoardReaderGsonTest {
       File file2 = new File("src/test/resources/JSON/Malformed.json");
       filePath = file2.getAbsolutePath();
 
-      board = boardReaderGson.readBoardFile(filePath, true);
+      board = ladderBoardReaderGson.readBoardFile(filePath, true);
       fail("Should throw an exception");
     } catch (RuntimeException e) {
       if (!e.getMessage().contains(

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardWriterGsonTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/board/LadderBoardWriterGsonTest.java
@@ -9,15 +9,15 @@ import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class BoardWriterGsonTest {
+class LadderBoardWriterGsonTest {
 
-  private BoardWriterGson boardWriterGson;
+  private LadderBoardWriterGson ladderBoardWriterGson;
   private BoardFileReader boardFileReader;
 
   @BeforeEach
   void setUp() {
-    boardWriterGson = new BoardWriterGson();
-    boardFileReader = new BoardReaderGson();
+    ladderBoardWriterGson = new LadderBoardWriterGson();
+    boardFileReader = new LadderBoardReaderGson();
   }
 
   @Test
@@ -32,7 +32,7 @@ class BoardWriterGsonTest {
     Board board = new Board(tiles);
 
     try {
-      boardWriterGson.writeBoardFile(board, filePath + "TestBoard2.json");
+      ladderBoardWriterGson.writeBoardFile(board, filePath + "TestBoard2.json");
 
       Board board2 = boardFileReader.readBoardFile(filePath + "TestBoard2.json", true);
 

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersReaderCsvTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersReaderCsvTest.java
@@ -2,6 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.io.player;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.util.List;
@@ -24,7 +25,7 @@ class PlayersReaderCsvTest {
       // check if it includes the players
       if (!player.getName().equals("styggve") && !player.getName().equals("sigern")
           && !player.getName().equals("liggve") && !player.getName().equals("sigve these nuts")) {
-        fail("Player not found in the list: " + player.getName());
+        fail("LadderGamePlayer not found in the list: " + player.getName());
       }
     });
 

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersWriterCsvTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/io/player/PlayersWriterCsvTest.java
@@ -2,6 +2,7 @@ package edu.ntnu.idi.idatt.boardgame.model.io.player;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import edu.ntnu.idi.idatt.boardgame.model.player.LadderGamePlayer;
 import edu.ntnu.idi.idatt.boardgame.model.player.Player;
 import edu.ntnu.idi.idatt.boardgame.model.player.PlayerPiece;
 import java.io.File;
@@ -17,8 +18,8 @@ class PlayersWriterCsvTest {
     String fileDirectory = "test.csv";
     String fileName = "test.csv";
     List<Player> players = new ArrayList<>();
-    players.add(new Player("Player1", PlayerPiece.MY_LOVE));
-    players.add(new Player("Player2", PlayerPiece.MARIOTINELLI));
+    players.add(new LadderGamePlayer("Player1", PlayerPiece.MY_LOVE));
+    players.add(new LadderGamePlayer("Player2", PlayerPiece.MARIOTINELLI));
 
     // Test writing to file
     writer.writePlayersFile(fileDirectory, fileName, players);

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/model/player/LadderGamePlayerTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/model/player/LadderGamePlayerTest.java
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class PlayerTest {
+class LadderGamePlayerTest {
 
-  private Player player;
+  private LadderGamePlayer player;
 
   @BeforeEach
   void setUp() {
-    player = new Player("TestPlayer", PlayerPiece.PAUL);
+    player = new LadderGamePlayer("TestPlayer", PlayerPiece.PAUL);
   }
 
   @AfterEach
@@ -95,8 +95,8 @@ class PlayerTest {
 
   @Test
   void testConstructorNegative() {
-    assertThrows(NullPointerException.class, () -> new Player(null, PlayerPiece.PAUL));
-    assertThrows(IllegalArgumentException.class, () -> new Player("", PlayerPiece.PAUL));
-    assertThrows(NullPointerException.class, () -> new Player("TestPlayer", null));
+    assertThrows(NullPointerException.class, () -> new LadderGamePlayer(null, PlayerPiece.PAUL));
+    assertThrows(IllegalArgumentException.class, () -> new LadderGamePlayer("", PlayerPiece.PAUL));
+    assertThrows(NullPointerException.class, () -> new LadderGamePlayer("TestPlayer", null));
   }
 }


### PR DESCRIPTION
# Changelog
## Added new tiles:
- added add coins tile
- added remove coins tile
- added add crown tile
- added mowser tile

## Added new TileActions:
- added a add coins tile action
- added a remove coins tile action
- added a add crown tile action
- added a remove crown tile action

## Redid the players:
This was done to make it easier to draw a line between the two game types.
- added an overall "Player" abstract class
- added LadderGamePlayer
- added ParioMartyPlayer

## Refactored some files:
- renamed the boardreader/writer to LadderBoardReader/Writer, since we do NOT have time to implement a custom board function for pario marty.